### PR TITLE
Fixed configurations of configurable products not being added to wishlist

### DIFF
--- a/Model/WishlistManagement.php
+++ b/Model/WishlistManagement.php
@@ -95,7 +95,7 @@ class WishlistManagement implements WishlistManagementInterface
                 }
             }
             if ($superAttributes) {
-                $buyRequest->setData('super_attributes', $superAttributes);
+                $buyRequest->setData('super_attribute', $superAttributes);
             }
             if ($bundleOptionQtys) {
                 $buyRequest->setData('bundle_option_qty', $bundleOptionQtys);


### PR DESCRIPTION
There was an issue where adding configurable products using API resulted in just the parent product being added to wishlist and not the configuration. This was fixed. Now the parent product will be added along with the selected configuration to wishlist.